### PR TITLE
Update virtaitech-orion-vgpu chart:

### DIFF
--- a/charts/virtaitech-orion-vgpu/v1.0.0/templates/clusterrole.yaml
+++ b/charts/virtaitech-orion-vgpu/v1.0.0/templates/clusterrole.yaml
@@ -2,12 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: orion-scheduler-cluster-admin
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    namespace: kube-system
+    namespace: {{ .Release.Namespace }}
     name: orion-scheduler

--- a/charts/virtaitech-orion-vgpu/v1.0.0/templates/controller.yaml
+++ b/charts/virtaitech-orion-vgpu/v1.0.0/templates/controller.yaml
@@ -48,8 +48,6 @@ spec:
         - name: ADMIN_PASSWD 
           # TODO: use secret?
           value: '{{ .Values.controller.password }}'
-        - name: ORION_LICENSE
-          value: '{{ .Values.license.key }}'
         - name: ENABLE_QUOTA
         {{- if eq .Values.controller.enableQuota true }}
           value: "1"

--- a/charts/virtaitech-orion-vgpu/v1.0.0/templates/controllerexternalservice.yaml
+++ b/charts/virtaitech-orion-vgpu/v1.0.0/templates/controllerexternalservice.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: orion-controller-external
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 spec:
   type: ExternalName
   # please make sure this dns entry pointing to the correct service name

--- a/charts/virtaitech-orion-vgpu/v1.0.0/templates/helper.yaml
+++ b/charts/virtaitech-orion-vgpu/v1.0.0/templates/helper.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   name: orion-helper
   labels:
     k8s-app: virtaitech

--- a/charts/virtaitech-orion-vgpu/v1.0.0/templates/scheduler.yaml
+++ b/charts/virtaitech-orion-vgpu/v1.0.0/templates/scheduler.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orion-scheduler
-  namespace: kube-system
+  Namespace: {{ .Release.Namespace }}
   labels:
     app: orion-scheduler
 spec:

--- a/charts/virtaitech-orion-vgpu/v1.0.0/templates/schedulerconfig.yaml
+++ b/charts/virtaitech-orion-vgpu/v1.0.0/templates/schedulerconfig.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: orion-scheduler-config
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 data:
   config.yaml: |
     apiVersion: kubescheduler.config.k8s.io/v1alpha1
@@ -11,9 +11,9 @@ data:
     algorithmSource:
       policy:
         configMap:
-          namespace: kube-system
+          namespace: {{ .Release.Namespace }}
           name: orion-scheduler-policy
     leaderElection:
       leaderElect: true
       lockObjectName: orion-scheduler
-      lockObjectNamespace: kube-system
+      lockObjectNamespace: {{ .Release.Namespace }}

--- a/charts/virtaitech-orion-vgpu/v1.0.0/templates/schedulerpolicy.yaml
+++ b/charts/virtaitech-orion-vgpu/v1.0.0/templates/schedulerpolicy.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: orion-scheduler-policy
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 data:
  policy.cfg : |
   {

--- a/charts/virtaitech-orion-vgpu/v1.0.0/templates/serviceaccount.yaml
+++ b/charts/virtaitech-orion-vgpu/v1.0.0/templates/serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: orion-scheduler
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
1. Move all resources into a single namespace.
2. Avoid exposing license to controller env.