### PR TITLE
[2.6] Rancher gpu sharing support k8s 1.23 1.24

### DIFF
--- a/charts/rancher-gpu-management/v0.0.7/.helmignore
+++ b/charts/rancher-gpu-management/v0.0.7/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/rancher-gpu-management/v0.0.7/Chart.yaml
+++ b/charts/rancher-gpu-management/v0.0.7/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
 name: rancher-gpu-management
 sources:
 - https://github.com/cnrancher
-version: 0.0.6
+version: 0.0.7
 appVersion: "0.1.0"
 home: https://github.com/cnrancher
 keywords:

--- a/charts/rancher-gpu-management/v0.0.7/Chart.yaml
+++ b/charts/rancher-gpu-management/v0.0.7/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+description: Provides gpu management for Rancher2.x
+engine: gotpl
+maintainers:
+- name: jianghang8421
+  email: hang.jiang@rancher.com
+name: rancher-gpu-management
+sources:
+- https://github.com/cnrancher
+version: 0.0.6
+appVersion: "0.1.0"
+home: https://github.com/cnrancher
+keywords:
+- sharing
+- management
+- gpu
+icon: https://raw.githubusercontent.com/jianghang8421/gpu-device-plugin-charts/master/nvidia_logo.png

--- a/charts/rancher-gpu-management/v0.0.7/README.md
+++ b/charts/rancher-gpu-management/v0.0.7/README.md
@@ -1,0 +1,1 @@
+# rancher-gpu-management

--- a/charts/rancher-gpu-management/v0.0.7/questions.yml
+++ b/charts/rancher-gpu-management/v0.0.7/questions.yml
@@ -1,0 +1,63 @@
+rancher_min_version: 2.4.11-rc1
+categories:
+- GPU Management
+questions:
+- variable: defaultImage
+  default: true
+  description: "Use default Docker image"
+  label: Use Default Image
+  type: boolean
+  show_subquestion_if: false
+  group: "Container Images"
+  subquestions:
+  - variable: image.nvidiadeviceplugin.repository
+    default: "nvidia/k8s-device-plugin"
+    description: "Nvidia GPU device plugin"
+    type: string
+    label: Nvidia GPU device plugin Image Name
+  - variable: image.nvidiadeviceplugin.tag
+    default: "1.0.0-beta4"
+    description: "Nvidia GPU device plugin image tag"
+    type: string
+    label: Image Tag
+  - variable: image.sharedeviceplugin.repository
+    default: "cnrancher/gpu-device-plugin"
+    description: "Shared GPU device plugin"
+    type: string
+    label: Shared GPU device plugin Image Name
+  - variable: image.sharedeviceplugin.tag
+    default: "v0.1.0"
+    description: "Shared GPU device plugin image tag"
+    type: string
+    label: Image Tag
+  - variable: image.schedulerextender.repository
+    default: "cnrancher/gpu-scheduler-extender"
+    description: "GPU Sharing scheduler extender"
+    type: string
+    label: Shared GPU device plugin Image Name
+  - variable: image.schedulerextender.tag
+    default: "v0.1.0"
+    description: "GPU Sharing scheduler extender tag"
+    type: string
+    label: Image Tag
+- variable: image.defaultScheduler.version
+  default: "v1.13"
+  description: "k8s version"
+  type: enum
+  label: K8S Version
+  options:
+    - v1.13
+    - v1.14
+    - v1.15
+    - v1.16
+    - v1.17
+    - v1.18
+    - v1.19
+    - v1.20
+    - v1.21
+    - v1.22
+- variable: memoryunit
+  default: "GiB"
+  description: "GPU Memory Unit: GiB or MiB"
+  type: string
+  label: GPU Memory Unit

--- a/charts/rancher-gpu-management/v0.0.7/questions.yml
+++ b/charts/rancher-gpu-management/v0.0.7/questions.yml
@@ -56,6 +56,8 @@ questions:
     - v1.20
     - v1.21
     - v1.22
+    - v1.23
+    - v1.24
 - variable: memoryunit
   default: "GiB"
   description: "GPU Memory Unit: GiB or MiB"

--- a/charts/rancher-gpu-management/v0.0.7/templates/_helpers.tpl
+++ b/charts/rancher-gpu-management/v0.0.7/templates/_helpers.tpl
@@ -1,0 +1,38 @@
+{{/*
+Get default scheduler image version by kubernetes version
+Supported versions map is set in .Values.image.defaultScheduler.supportedVersions
+*/}}
+{{- define "gpushare.defaultscheduler.image" -}}
+{{- range $key, $val := .Values.image.defaultScheduler.supportedVersions }}
+{{- if eq $.Values.image.defaultScheduler.version $key -}}
+    {{ $val }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get Rancher system-default-registry
+*/}}
+{{- define "system_default_registry" -}}
+{{- if .Values.global.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Use new scheduler config
+*/}}
+{{- define "use_new_scheduler_config" -}}
+{{- if eq .Values.image.defaultScheduler.version "v1.19" -}}
+{{- "true" -}}
+{{- else if .Values.image.defaultScheduler.version "v1.20" -}}
+{{- "true" -}}
+{{- else if .Values.image.defaultScheduler.version "v1.21" -}}
+{{- "true" -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/rancher-gpu-management/v0.0.7/templates/device-plugin-auth.yaml
+++ b/charts/rancher-gpu-management/v0.0.7/templates/device-plugin-auth.yaml
@@ -1,0 +1,56 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gpushare-device-plugin
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+  - update
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gpushare-device-plugin
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gpushare-device-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gpushare-device-plugin
+subjects:
+- kind: ServiceAccount
+  name: gpushare-device-plugin
+  namespace: {{ .Release.Namespace }}

--- a/charts/rancher-gpu-management/v0.0.7/templates/device-plugin.yaml
+++ b/charts/rancher-gpu-management/v0.0.7/templates/device-plugin.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gpushare-device-plugin
+spec:
+  selector:
+    matchLabels:
+      component: gpushare-device-plugin
+      app: gpushare
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        component: gpushare-device-plugin
+        app: gpushare
+    spec:
+      serviceAccount: gpushare-device-plugin
+      hostNetwork: true
+      nodeSelector:
+        gpu.cattle.io/type: "share"
+      containers:
+      - image: "{{ template "system_default_registry" . }}{{ .Values.image.sharedeviceplugin.repository }}:{{ .Values.image.sharedeviceplugin.tag }}"
+        name: gpushare-device-plugin
+        # Make this pod as Guaranteed pod which will never be evicted because of node's resource consumption.
+        command:
+          - gpu-device-plugin
+          - -logtostderr
+          - --v=5
+          - --memory-unit={{ .Values.memoryunit }}
+        resources:
+          limits:
+            memory: "300Mi"
+            cpu: "1"
+          requests:
+            memory: "300Mi"
+            cpu: "1"
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/kubelet.conf
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+          - name: device-plugin
+            mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins

--- a/charts/rancher-gpu-management/v0.0.7/templates/official-device-plugin.yaml
+++ b/charts/rancher-gpu-management/v0.0.7/templates/official-device-plugin.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-gpu-device-plugin
+spec:
+  selector:
+    matchLabels:
+      component: nvidia-gpu-device-plugin
+      app: nvidia
+  template:
+    metadata:
+      labels:
+        component: nvidia-gpu-device-plugin
+        app: nvidia
+    spec:
+      containers:
+      - image: "{{ template "system_default_registry" . }}{{ .Values.image.nvidiadeviceplugin.repository }}:{{ .Values.image.nvidiadeviceplugin.tag }}"
+        name: nvidia-gpu-device-plugin
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+          - name: device-plugin
+            mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+      nodeSelector:
+        gpu.cattle.io/type: 'default'

--- a/charts/rancher-gpu-management/v0.0.7/templates/scheduler-extender-auth.yaml
+++ b/charts/rancher-gpu-management/v0.0.7/templates/scheduler-extender-auth.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gpushare-scheduler-cluster-admin
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    namespace: {{ .Release.Namespace }}
+    name: gpushare-extender
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gpushare-extender

--- a/charts/rancher-gpu-management/v0.0.7/templates/scheduler-extender-config.yaml
+++ b/charts/rancher-gpu-management/v0.0.7/templates/scheduler-extender-config.yaml
@@ -1,0 +1,73 @@
+{{- if or (eq .Values.image.defaultScheduler.version "v1.19") (eq .Values.image.defaultScheduler.version "v1.20") (eq .Values.image.defaultScheduler.version "v1.21") (eq .Values.image.defaultScheduler.version "v1.22") -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gpushare-scheduler-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1beta1
+    kind: KubeSchedulerConfiguration
+    profiles:
+      - schedulerName: {{ .Values.schedulerextender.schedulerName }}
+    leaderElection:
+      leaderElect: false
+    extenders:
+      - urlPrefix: "http://localhost:{{ .Values.schedulerextender.port }}/gpushare-scheduler"
+        filterVerb: "filter"
+        bindVerb: "bind"
+        enableHTTPS: false
+        nodeCacheCapable: true
+        managedResources:
+          - name: "rancher.io/gpu-mem"
+            ignoredByScheduler: false
+        ignorable: false
+{{- else -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gpushare-scheduler-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1alpha1
+    kind: KubeSchedulerConfiguration
+    schedulerName: {{ .Values.schedulerextender.schedulerName }}
+    algorithmSource:
+      policy:
+        configMap:
+          namespace: {{ .Release.Namespace }}
+          name: gpushare-scheduler-policy
+    leaderElection:
+      leaderElect: true
+      lockObjectName: gpushare-scheduler
+      lockObjectNamespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gpushare-scheduler-policy
+  namespace: {{ .Release.Namespace }}
+data:
+ policy.cfg : |
+  {
+    "kind": "Policy",
+    "apiVersion": "v1",
+    "extenders": [
+      {
+        "urlPrefix": "http://localhost:{{ .Values.schedulerextender.port }}/gpushare-scheduler",
+        "filterVerb": "filter",
+        "bindVerb":   "bind",
+        "enableHttps": false,
+        "nodeCacheCapable": true,
+        "managedResources": [
+          {
+            "name": "rancher.io/gpu-mem",
+            "ignoredByScheduler": false
+          }
+        ],
+        "ignorable": false
+      }
+    ]
+  }
+{{- end -}}

--- a/charts/rancher-gpu-management/v0.0.7/templates/scheduler-extender-config.yaml
+++ b/charts/rancher-gpu-management/v0.0.7/templates/scheduler-extender-config.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.image.defaultScheduler.version "v1.19") (eq .Values.image.defaultScheduler.version "v1.20") (eq .Values.image.defaultScheduler.version "v1.21") (eq .Values.image.defaultScheduler.version "v1.22") -}}
+{{- if or (eq .Values.image.defaultScheduler.version "v1.19") (eq .Values.image.defaultScheduler.version "v1.20") (eq .Values.image.defaultScheduler.version "v1.21") (eq .Values.image.defaultScheduler.version "v1.22") (eq .Values.image.defaultScheduler.version "v1.23") (eq .Values.image.defaultScheduler.version "v1.24") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/rancher-gpu-management/v0.0.7/templates/scheduler-extender.yaml
+++ b/charts/rancher-gpu-management/v0.0.7/templates/scheduler-extender.yaml
@@ -1,0 +1,54 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: gpushare-schd-extender
+spec:
+  selector:
+    matchLabels:
+      app: gpushare
+      component: gpushare-schd-extender
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: gpushare
+        component: gpushare-schd-extender
+      annotations:
+    spec:
+      {{- with .Values.schedulerextender.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.schedulerextender.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.schedulerextender.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      serviceAccount: gpushare-extender
+      volumes:
+      - name: gpushare-scheduler-config
+        configMap:
+          name: gpushare-scheduler-config
+      containers:
+        - name: gpushare-default-scheduler
+          image: {{ template "system_default_registry" . }}{{template "gpushare.defaultscheduler.image" .}}
+          args:
+          - kube-scheduler
+          - --config=/gpushare-scheduler/config.yaml
+          - -v={{- .Values.schedulerextender.verbose }}
+          volumeMounts:
+          - name: gpushare-scheduler-config
+            mountPath: /gpushare-scheduler
+        - name: gpushare-scheduler-extender
+          image: "{{ template "system_default_registry" . }}{{ .Values.image.schedulerextender.repository }}:{{ .Values.image.schedulerextender.tag }}"
+          env:
+          - name: LOG_LEVEL
+            value: debug
+          - name: PORT
+            value: "{{ .Values.schedulerextender.port }}"

--- a/charts/rancher-gpu-management/v0.0.7/values.yaml
+++ b/charts/rancher-gpu-management/v0.0.7/values.yaml
@@ -1,0 +1,34 @@
+image:
+  nvidiadeviceplugin:
+    repository: cnrancher/k8s-device-plugin
+    tag: "v0.10.0"
+  sharedeviceplugin:
+    repository: cnrancher/gpu-device-plugin
+    tag: "v0.1.0"
+  schedulerextender:
+    repository: cnrancher/gpu-scheduler-extender
+    tag: "v0.1.0"
+  defaultScheduler:
+    version: v1.13
+    supportedVersions:
+      v1.13: "rancher/hyperkube:v1.13.12-rancher2"
+      v1.14: "rancher/hyperkube:v1.14.10-rancher1"
+      v1.15: "rancher/hyperkube:v1.15.12-rancher2"
+      v1.16: "rancher/hyperkube:v1.16.15-rancher2"
+      v1.17: "rancher/hyperkube:v1.17.14-rancher1"
+      v1.18: "rancher/hyperkube:v1.18.12-rancher1"
+      v1.19: "rancher/hyperkube:v1.19.16-rancher1"
+      v1.20: "rancher/hyperkube:v1.20.13-rancher1"
+      v1.21: "rancher/hyperkube:v1.21.8-rancher1"
+      v1.22: "rancher/hyperkube:v1.21.8-rancher1"
+schedulerextender:
+  schedulerName: rancher-gpushare-scheduler
+  port: 9100
+  verbose: 4
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+# GPU Sharing Memory unit: GiB or MiB    
+memoryunit: GiB
+global:
+  systemDefaultRegistry: ""

--- a/charts/rancher-gpu-management/v0.0.7/values.yaml
+++ b/charts/rancher-gpu-management/v0.0.7/values.yaml
@@ -21,6 +21,8 @@ image:
       v1.20: "rancher/hyperkube:v1.20.13-rancher1"
       v1.21: "rancher/hyperkube:v1.21.8-rancher1"
       v1.22: "rancher/hyperkube:v1.21.8-rancher1"
+      v1.23: "rancher/hyperkube:v1.21.8-rancher1"
+      v1.24: "rancher/hyperkube:v1.21.8-rancher1"
 schedulerextender:
   schedulerName: rancher-gpushare-scheduler
   port: 9100


### PR DESCRIPTION
https://github.com/cnrancher/pandaria-test-plan/issues/222#issuecomment-1235040079

对于1.23 1.24版本的k8s同样使用`rancher/hyperkube:v1.21.8-rancher1`镜像作为扩展scheduler。
因为更高版本的scheduler使用的`apiVersion: kubescheduler.config.k8s.io/v1beta1`进行配置时会报错。