### PR TITLE
[2.6] PANDARIA: Add hull tests

### DIFF
--- a/tests/rancher-gpu-monitoring/rancher_gpu_monitoring.go
+++ b/tests/rancher-gpu-monitoring/rancher_gpu_monitoring.go
@@ -1,0 +1,98 @@
+package rancher_gpu_monitoring
+
+import (
+	"github.com/rancher/hull/pkg/chart"
+	"github.com/rancher/hull/pkg/checker"
+	"github.com/rancher/hull/pkg/test"
+	"github.com/rancher/hull/pkg/utils"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var ChartPath = utils.MustGetPathFromModuleRoot("/charts/rancher-gpu-monitoring/0.0.1")
+
+var (
+	DefaultReleaseName = "rancher-monitoring-test-1"
+	DefaultNamespace   = "default"
+)
+
+var suite = test.Suite{
+	ChartPath: ChartPath,
+
+	Cases: []test.Case{
+		{
+			Name: "Default",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace),
+		},
+		{
+			Name: "systemdefaultregistry",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).
+				Set("global.systemDefaultRegistry", "testrancher.io"),
+		},
+		{
+			Name: "Use runtime class",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).
+				Set("runtimeClassName", "nvidia"),
+		},
+	},
+
+	NamedChecks: []test.NamedCheck{
+		{
+			Name: "Check image repository and tag",
+			Covers: []string{
+				".Values.image.repository",
+				".Values.image.tag",
+			},
+
+			Checks: test.Checks{
+				checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+					systemDefaultRegistry, _ := checker.RenderValue[string](tc, ".Values.global.systemDefaultRegistry")
+					imageRepository, _ := checker.RenderValue[string](tc, ".Values.image.repository")
+					imageTag, _ := checker.RenderValue[string](tc, ".Values.image.tag")
+					expectedImage := imageRepository + ":" + imageTag
+
+					if systemDefaultRegistry != "" {
+						expectedImage = systemDefaultRegistry + "/" + expectedImage
+					}
+
+					for _, container := range podTemplateSpec.Spec.Containers {
+						assert.Equal(tc.T, expectedImage, container.Image,
+							"workload %s (type: %T) in workload %s/%s does not have correct image",
+							container.Name, obj, obj.GetNamespace(), obj.GetName(),
+						)
+					}
+				}),
+			},
+		},
+
+		{
+			Name: "Check runtime class",
+			Covers: []string{
+				".Values.runtimeClassName",
+			},
+
+			Checks: test.Checks{
+				checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+					runtimeClassName, _ := checker.RenderValue[string](tc, ".Values.runtimeClassName")
+					if podTemplateSpec.Spec.RuntimeClassName == nil {
+						assert.Equal(tc.T, runtimeClassName, "",
+							"workload %s (type: %T) in Deployment %s/%s does not have correct runtimeclass",
+							podTemplateSpec.Name, obj, obj.GetNamespace(), obj.GetName(),
+						)
+					} else {
+						assert.Equal(tc.T, runtimeClassName, *podTemplateSpec.Spec.RuntimeClassName,
+							"workload %s (type: %T) in Deployment %s/%s does not have correct runtimeclass",
+							podTemplateSpec.Name, obj, obj.GetNamespace(), obj.GetName(),
+						)
+					}
+
+				}),
+			},
+		},
+	},
+}

--- a/tests/rancher-gpu-monitoring/rancher_gpu_monitoring_test.go
+++ b/tests/rancher-gpu-monitoring/rancher_gpu_monitoring_test.go
@@ -1,0 +1,16 @@
+package rancher_gpu_monitoring
+
+import (
+	"testing"
+
+	"github.com/rancher/hull/pkg/test"
+)
+
+func TestChart(t *testing.T) {
+	opts := test.GetRancherOptions()
+	opts.HelmLint.Rancher.Enabled = false
+	opts.Coverage.Disabled = true
+	// opts.Coverage.IncludeSubcharts = false
+	// opts.YAMLLint.Enabled = false
+	suite.Run(t, opts)
+}

--- a/tests/rancher-gpu-sharing/rancher_gpu_sharing.go
+++ b/tests/rancher-gpu-sharing/rancher_gpu_sharing.go
@@ -1,0 +1,180 @@
+package rancher_gpu_sharing
+
+import (
+	"github.com/rancher/hull/pkg/chart"
+	"github.com/rancher/hull/pkg/checker"
+	"github.com/rancher/hull/pkg/test"
+	"github.com/rancher/hull/pkg/utils"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var ChartPath = utils.MustGetPathFromModuleRoot("/charts/rancher-gpu-sharing/0.0.1")
+
+var (
+	DefaultReleaseName = "rancher-sharing-test-1"
+	DefaultNamespace   = "default"
+)
+
+var suite = test.Suite{
+	ChartPath: ChartPath,
+
+	Cases: []test.Case{
+		{
+			Name: "1.23",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).
+				Set("defaultScheduler.version", "v1.23"),
+		},
+		{
+			Name: "1.24",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).
+				Set("defaultScheduler.version", "v1.24"),
+		},
+		{
+			Name: "1.25",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).
+				Set("defaultScheduler.version", "v1.25"),
+		},
+		{
+			Name: "systemdefaultregistry",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).
+				Set("global.systemDefaultRegistry", "testrancher.io"),
+		},
+		{
+			Name: "Use runtime class",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).
+				Set("runtimeClassName", "nvidia"),
+		},
+	},
+
+	NamedChecks: []test.NamedCheck{
+		{
+			Name: "Check shared device plugin repository and tag",
+			Covers: []string{
+				".Values.sharedeviceplugin.image.repository",
+				".Values.sharedeviceplugin.image.tag",
+			},
+
+			Checks: test.Checks{
+				checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+					if obj.GetName() != "gpushare-device-plugin" {
+						return
+					}
+					systemDefaultRegistry, _ := checker.RenderValue[string](tc, ".Values.global.systemDefaultRegistry")
+					sdRepository, _ := checker.RenderValue[string](tc, ".Values.sharedeviceplugin.image.repository")
+					sdTag, _ := checker.RenderValue[string](tc, ".Values.sharedeviceplugin.image.tag")
+					expectedSDImage := sdRepository + ":" + sdTag
+
+					if systemDefaultRegistry != "" {
+						expectedSDImage = systemDefaultRegistry + "/" + expectedSDImage
+					}
+
+					for _, container := range podTemplateSpec.Spec.Containers {
+						assert.Equal(tc.T, expectedSDImage, container.Image,
+							"workload %s (type: %T) in Deployment %s/%s does not have correct image",
+							container.Name, obj, obj.GetNamespace(), obj.GetName(),
+						)
+					}
+				}),
+			},
+		},
+
+		{
+			Name: "Check defaultScheduler repository and tag",
+			Covers: []string{
+				".Values.defaultScheduler",
+			},
+
+			Checks: test.Checks{
+				checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+					if obj.GetName() != "gpushare-schd-extender" {
+						return
+					}
+					systemDefaultRegistry, _ := checker.RenderValue[string](tc, ".Values.global.systemDefaultRegistry")
+
+					defaultSchedulerVersion, _ := checker.RenderValue[string](tc, ".Values.defaultScheduler.version")
+
+					supportedVersions, _ := checker.RenderValue[map[string]interface{}](tc,
+						".Values.defaultScheduler.supportedVersions")
+
+					image123 := supportedVersions["v1.23"].(map[string]interface{})
+					defaultSchedulerRepository123 := image123["repository"].(string)
+					defaultSchedulerTag123 := image123["tag"].(string)
+					expectedImage123 := defaultSchedulerRepository123 + ":" + defaultSchedulerTag123
+
+					image124 := supportedVersions["v1.24"].(map[string]interface{})
+					defaultSchedulerRepository124 := image124["repository"].(string)
+					defaultSchedulerTag124 := image124["tag"].(string)
+					expectedImage124 := defaultSchedulerRepository124 + ":" + defaultSchedulerTag124
+
+					schedulerExtenderRepo, _ := checker.RenderValue[string](tc, ".Values.schedulerextender.image.repository")
+					schedulerExtenderTag, _ := checker.RenderValue[string](tc, ".Values.schedulerextender.image.tag")
+					expectedSchedulerExtenderImage := schedulerExtenderRepo + ":" + schedulerExtenderTag
+
+					if systemDefaultRegistry != "" {
+						expectedImage123 = systemDefaultRegistry + "/" + expectedImage123
+						expectedImage124 = systemDefaultRegistry + "/" + expectedImage124
+						expectedSchedulerExtenderImage = systemDefaultRegistry + "/" + expectedSchedulerExtenderImage
+					}
+
+					for _, container := range podTemplateSpec.Spec.Containers {
+						if container.Name == "gpushare-default-scheduler" {
+							if defaultSchedulerVersion == "v1.23" {
+								assert.Equal(tc.T, expectedImage123, container.Image,
+									"workload %s (type: %T) in Deployment %s/%s does not have correct image",
+									container.Name, obj, obj.GetNamespace(), obj.GetName(),
+								)
+							} else if defaultSchedulerVersion == "v1.24" {
+								assert.Equal(tc.T, expectedImage124, container.Image,
+									"workload %s (type: %T) in Deployment %s/%s does not have correct image",
+									container.Name, obj, obj.GetNamespace(), obj.GetName(),
+								)
+							}
+						} else if container.Name == "gpushare-scheduler-extender" {
+							assert.Equal(tc.T, expectedSchedulerExtenderImage, container.Image,
+								"workload %s (type: %T) in Deployment %s/%s does not have correct image",
+								container.Name, obj, obj.GetNamespace(), obj.GetName(),
+							)
+						}
+					}
+				}),
+			},
+		},
+
+		{
+			Name: "Check runtime class",
+			Covers: []string{
+				".Values.defaultScheduler",
+			},
+
+			Checks: test.Checks{
+				checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+					if obj.GetName() != "gpushare-device-plugin" {
+						return
+					}
+
+					runtimeClassName, _ := checker.RenderValue[string](tc, ".Values.runtimeClassName")
+					if podTemplateSpec.Spec.RuntimeClassName == nil {
+						assert.Equal(tc.T, runtimeClassName, "",
+							"workload %s (type: %T) in Deployment %s/%s does not have correct image",
+							podTemplateSpec.Name, obj, obj.GetNamespace(), obj.GetName(),
+						)
+					} else {
+						assert.Equal(tc.T, runtimeClassName, *podTemplateSpec.Spec.RuntimeClassName,
+							"workload %s (type: %T) in Deployment %s/%s does not have correct image",
+							podTemplateSpec.Name, obj, obj.GetNamespace(), obj.GetName(),
+						)
+					}
+
+				}),
+			},
+		},
+	},
+}

--- a/tests/rancher-gpu-sharing/rancher_gpu_sharing_test.go
+++ b/tests/rancher-gpu-sharing/rancher_gpu_sharing_test.go
@@ -1,0 +1,16 @@
+package rancher_gpu_sharing
+
+import (
+	"testing"
+
+	"github.com/rancher/hull/pkg/test"
+)
+
+func TestChart(t *testing.T) {
+	opts := test.GetRancherOptions()
+	opts.HelmLint.Rancher.Enabled = false
+	opts.Coverage.Disabled = true
+	// opts.Coverage.IncludeSubcharts = false
+	// opts.YAMLLint.Enabled = false
+	suite.Run(t, opts)
+}

--- a/tests/rancher-k8s-auditlog-collector/rancher_k8s_auditlog_collector.go
+++ b/tests/rancher-k8s-auditlog-collector/rancher_k8s_auditlog_collector.go
@@ -1,0 +1,186 @@
+package rancher_k8s_auditlog_collector
+
+import (
+	"fmt"
+
+	"github.com/rancher/hull/pkg/chart"
+	"github.com/rancher/hull/pkg/checker"
+	"github.com/rancher/hull/pkg/test"
+	"github.com/rancher/hull/pkg/utils"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var ChartPath = utils.MustGetPathFromModuleRoot("/charts/rancher-k8s-auditlog-collector/0.0.2")
+
+var (
+	DefaultReleaseName = "rancher-k8s-auditlog-collector-test-1"
+	DefaultNamespace   = "default"
+)
+
+var suite = test.Suite{
+	ChartPath: ChartPath,
+
+	Cases: []test.Case{
+		{
+			Name: "File mode",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).
+				Set("auditlogServerPort", "9000").
+				Set("auditlogServerHost", "1.1.1.1").
+				Set("clusterid", "c-xxxx"),
+		},
+		{
+			Name: "Webhook mode",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).
+				Set("auditlogServerPort", "9000").
+				Set("auditlogServerHost", "1.1.1.1").
+				Set("mode", "webhook").
+				Set("webhook.servicePort", "8787").
+				Set("webhook.serviceNodePort", "30121").
+				Set("clusterid", "c-xxxx"),
+		},
+	},
+
+	NamedChecks: []test.NamedCheck{
+		{
+			Name:   "Check auditlog server and cluster config",
+			Covers: []string{"auditlogServerHost", "auditlogServerPort", "clusterid"},
+			Checks: test.Checks{
+				checker.PerResource(func(tc *checker.TestContext, configmap *corev1.ConfigMap) {
+					auditlogServerPort, _ := checker.RenderValue[string](tc, ".Values.auditlogServerPort")
+					auditlogServerHost, _ := checker.RenderValue[string](tc, ".Values.auditlogServerHost")
+					clusterid, _ := checker.RenderValue[string](tc, ".Values.clusterid")
+
+					assert.Contains(tc.T,
+						configmap.Data, "main.conf",
+						"%T %s does not have 'main.conf' key", configmap, checker.Key(configmap),
+					)
+					assert.Contains(tc.T,
+						configmap.Data["main.conf"], auditlogServerHost,
+						"%T %s does not have auditlog server host setting", configmap, checker.Key(configmap),
+					)
+					assert.Contains(tc.T,
+						configmap.Data["main.conf"], auditlogServerPort,
+						"%T %s does not have auditlog server port setting", configmap, checker.Key(configmap),
+					)
+					assert.Contains(tc.T,
+						configmap.Data["main.conf"], clusterid,
+						"%T %s does not have cluster id setting", configmap, checker.Key(configmap),
+					)
+				}),
+			},
+		},
+		{
+			Name: "Check fluentbit repository and tag",
+			Covers: []string{
+				".Values.global.systemDefaultRegistry",
+				".Values.fluentbit.image.repository",
+				".Values.fluentbit.image.tag",
+			},
+
+			Checks: test.Checks{
+				checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+					if obj.GetName() != "rancher-k8s-auditlog-fluentbit-file" &&
+						obj.GetName() != "rancher-k8s-auditlog-fluentbit-webhook" {
+						return
+					}
+					systemDefaultRegistry, _ := checker.RenderValue[string](tc, ".Values.global.systemDefaultRegistry")
+					fluentbitRepository, _ := checker.RenderValue[string](tc, ".Values.fluentbit.image.repository")
+					fluentbitTag, _ := checker.RenderValue[string](tc, ".Values.fluentbit.image.tag")
+					expectedFluentbitImage := fluentbitRepository + ":" + fluentbitTag
+
+					if systemDefaultRegistry != "" {
+						expectedFluentbitImage = systemDefaultRegistry + "/" + expectedFluentbitImage
+					}
+
+					for _, container := range podTemplateSpec.Spec.Containers {
+						assert.Equal(tc.T, expectedFluentbitImage, container.Image,
+							"workload %s (type: %T) in Deployment %s/%s does not have correct image",
+							container.Name, obj, obj.GetNamespace(), obj.GetName(),
+						)
+					}
+				}),
+			},
+		},
+
+		{
+			Name: "Check webhook service",
+			Covers: []string{
+				".Values.webhook.servicePort",
+				".Values.webhook.serviceNodePort",
+			},
+
+			Checks: test.Checks{
+				checker.PerResource(func(tc *checker.TestContext, service *corev1.Service) {
+					mode, _ := checker.RenderValue[string](tc, ".Values.mode")
+					if mode != "webhook" {
+						return
+					}
+
+					servicePort, _ := checker.RenderValue[string](tc, ".Values.webhook.servicePort")
+					serviceNodePort, _ := checker.RenderValue[string](tc, ".Values.webhook.serviceNodePort")
+
+					for _, port := range service.Spec.Ports {
+						assert.Equal(tc.T,
+							fmt.Sprint(port.TargetPort.IntVal), servicePort,
+							"%T %s does not serivceport error", service, checker.Key(service),
+						)
+						assert.Equal(tc.T,
+							fmt.Sprint(port.NodePort), serviceNodePort,
+							"%T %s does not serivceport error", service, checker.Key(service),
+						)
+					}
+
+				}),
+			},
+		},
+
+		{
+			Name: "Check file mode",
+			Covers: []string{
+				".Values.apiserverLogPath",
+				".Values.apiserverLogFile",
+			},
+
+			Checks: test.Checks{
+				checker.PerResource(func(tc *checker.TestContext, configmap *corev1.ConfigMap) {
+					mode, _ := checker.RenderValue[string](tc, ".Values.mode")
+					if mode != "file" {
+						return
+					}
+
+					apiserverLogFile, _ := checker.RenderValue[string](tc, ".Values.apiserverLogFile")
+
+					assert.Contains(tc.T,
+						configmap.Data["main.conf"], fmt.Sprintf("/var/log/kubernetes/audit/%s", apiserverLogFile),
+						"%T %s does not serivceport error", configmap, checker.Key(configmap),
+					)
+				}),
+				checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+					mode, _ := checker.RenderValue[string](tc, ".Values.mode")
+					if mode != "file" {
+						return
+					}
+
+					if obj.GetName() != "rancher-k8s-auditlog-fluentbit-file" {
+						return
+					}
+					apiserverLogPath, _ := checker.RenderValue[string](tc, ".Values.apiserverLogPath")
+
+					for _, v := range podTemplateSpec.Spec.Volumes {
+						if v.Name == "kubeapiserver-log" {
+							assert.Equal(tc.T, apiserverLogPath, v.HostPath.Path,
+								"%s/%s does not have correct volume",
+								obj.GetNamespace(), obj.GetName(),
+							)
+						}
+					}
+				}),
+			},
+		},
+	},
+}

--- a/tests/rancher-k8s-auditlog-collector/rancher_k8s_auditlog_collector_test.go
+++ b/tests/rancher-k8s-auditlog-collector/rancher_k8s_auditlog_collector_test.go
@@ -1,0 +1,16 @@
+package rancher_k8s_auditlog_collector
+
+import (
+	"testing"
+
+	"github.com/rancher/hull/pkg/test"
+)
+
+func TestChart(t *testing.T) {
+	opts := test.GetRancherOptions()
+	opts.HelmLint.Rancher.Enabled = false
+	opts.Coverage.Disabled = true
+	// opts.Coverage.IncludeSubcharts = false
+	// opts.YAMLLint.Enabled = false
+	suite.Run(t, opts)
+}

--- a/tests/rancher-nvidia-k8s-device-plugin/rancher_nvidia_k8s_device_plugin.go
+++ b/tests/rancher-nvidia-k8s-device-plugin/rancher_nvidia_k8s_device_plugin.go
@@ -1,0 +1,186 @@
+package rancher_nvidia_k8s_device_plugin
+
+import (
+	"fmt"
+
+	"github.com/rancher/hull/pkg/chart"
+	"github.com/rancher/hull/pkg/checker"
+	"github.com/rancher/hull/pkg/test"
+	"github.com/rancher/hull/pkg/utils"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var ChartPath = utils.MustGetPathFromModuleRoot("/charts/rancher-nvidia-k8s-device-plugin/0.0.3")
+
+var (
+	DefaultReleaseName = "rancher-nvidia-k8s-device-plugin-test-1"
+	DefaultNamespace   = "test-nvidia"
+)
+
+var suite = test.Suite{
+	ChartPath: ChartPath,
+
+	Cases: []test.Case{
+		{
+			Name: "Default",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).
+				Set("global.systemDefaultRegistry", "testrancher.io"),
+		},
+		{
+			Name: "systemdefaultregistry",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).
+				Set("global.systemDefaultRegistry", "testrancher.io"),
+		},
+		{
+			Name: "gfd disable",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).
+				Set("gfd.enabled", false).
+				Set("global.systemDefaultRegistry", "testrancher.io"),
+		},
+		{
+			Name: "Use runtime class",
+
+			TemplateOptions: chart.NewTemplateOptions(DefaultReleaseName, DefaultNamespace).
+				Set("runtimeClassName", "nvidia").
+				Set("global.systemDefaultRegistry", "testrancher.io"),
+		},
+	},
+
+	NamedChecks: []test.NamedCheck{
+		{
+			Name: "Check image repository and tag",
+			Covers: []string{
+				".Values.image.repository",
+				".Values.image.tag",
+			},
+
+			Checks: test.Checks{
+				checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+					systemDefaultRegistry, _ := checker.RenderValue[string](tc, ".Values.global.systemDefaultRegistry")
+					imageRepository, _ := checker.RenderValue[string](tc, ".Values.image.repository")
+					imageTag, _ := checker.RenderValue[string](tc, ".Values.image.tag")
+					expectedImage := imageRepository + ":" + imageTag
+
+					if systemDefaultRegistry != "" {
+						expectedImage = systemDefaultRegistry + "/" + expectedImage
+					}
+
+					for _, container := range podTemplateSpec.Spec.Containers {
+						if container.Name == "nvidia-device-plugin-init" ||
+							container.Name == "nvidia-device-plugin-sidecar" ||
+							container.Name == "nvidia-device-plugin-ctr" {
+							assert.Equal(tc.T, expectedImage, container.Image,
+								"workload %s (type: %T) in workload %s/%s does not have correct image",
+								container.Name, obj, obj.GetNamespace(), obj.GetName(),
+							)
+						}
+					}
+				}),
+			},
+		},
+
+		{
+			Name: "Check runtime class",
+			Covers: []string{
+				".Values.runtimeClassName",
+			},
+
+			Checks: test.Checks{
+				checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+					if obj.GetName() != DefaultReleaseName {
+						return
+					}
+
+					runtimeClassName, _ := checker.RenderValue[string](tc, ".Values.runtimeClassName")
+					if podTemplateSpec.Spec.RuntimeClassName == nil {
+						assert.Equal(tc.T, runtimeClassName, "",
+							"workload %s (type: %T) in Deployment %s/%s does not have correct runtimeclass",
+							podTemplateSpec.Name, obj, obj.GetNamespace(), obj.GetName(),
+						)
+					} else {
+						assert.Equal(tc.T, runtimeClassName, *podTemplateSpec.Spec.RuntimeClassName,
+							"workload %s (type: %T) in Deployment %s/%s does not have correct runtimeclass",
+							podTemplateSpec.Name, obj, obj.GetNamespace(), obj.GetName(),
+						)
+					}
+
+				}),
+			},
+		},
+
+		{
+			Name: "Check gfd image",
+			Covers: []string{
+				".Values.gfd.image.repository",
+				".Values.gfd.image.tag",
+			},
+
+			Checks: test.Checks{
+				checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+					gfdenabled, _ := checker.RenderValue[bool](tc, ".Values.gfd.enabled")
+					if !gfdenabled {
+						return
+					}
+
+					systemDefaultRegistry, _ := checker.RenderValue[string](tc, ".Values.global.systemDefaultRegistry")
+					imageRepository, _ := checker.RenderValue[string](tc, ".Values.gfd.image.repository")
+					imageTag, _ := checker.RenderValue[string](tc, ".Values.gfd.image.tag")
+					expectedImage := imageRepository + ":" + imageTag
+
+					if systemDefaultRegistry != "" {
+						expectedImage = systemDefaultRegistry + "/" + expectedImage
+					}
+
+					for _, container := range podTemplateSpec.Spec.Containers {
+						if container.Name == "gpu-feature-discovery-init" ||
+							container.Name == "gpu-feature-discovery-sidecar" ||
+							container.Name == "gpu-feature-discovery-ctr" {
+							assert.Equal(tc.T, expectedImage, container.Image,
+								"workload %s (type: %T) in workload %s/%s does not have correct image",
+								container.Name, obj, obj.GetNamespace(), obj.GetName(),
+							)
+						}
+					}
+				}),
+			},
+		},
+
+		{
+			Name: "Check gfd disable",
+			Covers: []string{
+				".Values.gfd.enbaled",
+			},
+
+			Checks: test.Checks{
+				checker.PerWorkload(func(tc *checker.TestContext, obj metav1.Object, podTemplateSpec corev1.PodTemplateSpec) {
+					if obj.GetName() != DefaultReleaseName {
+						return
+					}
+					gfdenabled, _ := checker.RenderValue[bool](tc, ".Values.gfd.enabled")
+					if gfdenabled {
+						return
+					}
+					fmt.Println(obj.GetName())
+					hasNodeSelector := false
+					for k, v := range podTemplateSpec.Spec.NodeSelector {
+						if k == "gpu.cattle.io/type" && v == "nvidia" {
+							hasNodeSelector = true
+						}
+					}
+
+					assert.Equal(tc.T, true, hasNodeSelector,
+						"workload %s/%s does not have nodeselector gpu.cattle.io/type:nvidia",
+						obj.GetNamespace(), obj.GetName(),
+					)
+				}),
+			},
+		},
+	},
+}

--- a/tests/rancher-nvidia-k8s-device-plugin/rancher_nvidia_k8s_device_plugin_test.go
+++ b/tests/rancher-nvidia-k8s-device-plugin/rancher_nvidia_k8s_device_plugin_test.go
@@ -1,0 +1,16 @@
+package rancher_nvidia_k8s_device_plugin
+
+import (
+	"testing"
+
+	"github.com/rancher/hull/pkg/test"
+)
+
+func TestChart(t *testing.T) {
+	opts := test.GetRancherOptions()
+	opts.HelmLint.Rancher.Enabled = false
+	opts.Coverage.Disabled = true
+	// opts.Coverage.IncludeSubcharts = false
+	// opts.YAMLLint.Enabled = false
+	suite.Run(t, opts)
+}


### PR DESCRIPTION
## Issue

为以下chart增加了hull单元测试。
- rancher-gpu-monitoring
- rancher-gpu-sharing
- rancher-k8s-auditlog-collector
- rancher-nvidia-k8s-device-plugin

## Checklist

- [ ] `Chart.yaml` 定义了以下 Annotation：
  - `catalog.cattle.io/rancher-version`
  - `catalog.cattle.io/kube-version`
    <!-- FYI: https://github.com/rancher/charts#rancher-version-annotations -->
- [ ] 支持 `systemDefaultRegistry` 设置，`values.yaml` 定义了：
    ```yaml
    global:
        systemDefaultRegistry: ""
    ```
- [ ] 容器镜像格式为 Manifest List。
    <!-- 如果为否，请在此补充原因 -->
- [ ] `values.yaml` 中容器镜像可以在 Rancher 构建镜像列表时被识别。
    ```yaml
    repository: cnrancher/mirrored-image-name
    tag: v1.0.0
    ```
- [ ] 容器镜像 TAG 不是 Beta 版本。
    <!-- 如果为否，请在此补充原因 -->
